### PR TITLE
Keyboard shortcut 'a' for 'Add entry' on timesheet.

### DIFF
--- a/app/assets/javascripts/time_entries.js.coffee
+++ b/app/assets/javascripts/time_entries.js.coffee
@@ -1,0 +1,5 @@
+$(document).keyup (event) ->
+  unless $("#time-modal").is(":visible")
+    if event.which is 65 # 'a'
+      $("a.button.add_time").first().click()
+  return

--- a/app/views/time_entries/_top_buttons.html.erb
+++ b/app/views/time_entries/_top_buttons.html.erb
@@ -1,5 +1,5 @@
 <div class="top-buttons">
-  <a href="#" class="button remote-reveal" data-reveal-id="time-modal" data-reveal-url="<%= new_user_time_entry_path(@user, date: @day) %>">
+  <a href="#" class="button remote-reveal add_time" data-reveal-id="time-modal" data-reveal-url="<%= new_user_time_entry_path(@user, date: @day) %>">
     <%= icon(:plus) %>
     <%= t '.add_time' %>
   </a>


### PR DESCRIPTION
I was trying out uberzeit and adding some time entries, but I got a bit annoyed that I had to take my hands off the keyboard to reach for the 'Add entry' button every time I try to add a lunch break.

With this keyboard shortcut, you just have to hit 'a' (no modifiers), enter some more times and then hit enter, rinse, repeat :)

I'm not sure if you want to handle keyboard shortcuts centrally at some point in the future, I notice some keyup events being used but I believe (?) they're in areas of the code that isn't used right now (time_sheets). I tried to add this in the most specific bit of code I could find.

I'd also like to add 'n' for 'next day' and 'p' for 'previous day', but I'll make this very very small in case you don't like it :)
