### PR TITLE
Add link to add absences for employees calendar view

### DIFF
--- a/app/assets/javascripts/absences.js.coffee
+++ b/app/assets/javascripts/absences.js.coffee
@@ -18,3 +18,8 @@ $ ->
   $('[data-add-absence-url]').css('cursor', 'pointer')
   $('[data-add-absence-url]').click (e) ->
     self.location.href = $(this).data('add-absence-url')
+
+  # autoreveal on load
+  setTimeout ->
+    $("[data-reveal-on-load]").click()
+  , 250

--- a/app/helpers/absences_helper.rb
+++ b/app/helpers/absences_helper.rb
@@ -38,6 +38,9 @@ module AbsencesHelper
     if can? :manage, Absence
       options.merge! :'data-reveal-id' => 'absence-modal', :'data-reveal-url' => new_user_absence_path(@user, date: day)
     end
+    if params[:add_absence_for_date] == day.to_s
+      options.merge! :'data-reveal-on-load' => ''
+    end
 
     [content, options]
   end

--- a/app/views/absences/index.html.erb
+++ b/app/views/absences/index.html.erb
@@ -29,12 +29,4 @@
 
 <% if can?(:manage, Absence) %>
   <%= render 'absence_modal' %>
-
-  <% unless params[:add_absence_for_date].blank? %>
-  <script type="text/javascript">
-    $(document).ready(function() {
-      $("[data-reveal-id='absence-modal'][data-date='<%= params[:add_absence_for_date] %>']").click();
-    });
-  </script>
-  <% end %>
 <% end %>

--- a/app/views/reports/absence/calendar.html.erb
+++ b/app/views/reports/absence/calendar.html.erb
@@ -35,7 +35,7 @@
               <% unless @work_days[day] %>non-work-day<% end %>
               <% unless absences.empty? %>has-tip<% end %>"
               <% unless absences.empty? %>data-tooltip="<%=render(partial: 'shared/absences_tooltip', locals: { absences: absences, day: day, edit: false }).to_s%>" <% end %>
-              <% if absences.empty? %>data-add-absence-url="<%= user_absences_path(user, add_absence_for_date: day) %>"<% end %>>
+              <% if absences.empty? %>data-add-absence-url="<%= year_user_absences_path(user, day.year, add_absence_for_date: day) %>"<% end %>>
                 <% unless absences.blank? %>
                   <div class="event-container">
                     <%= render_absences(absences).html_safe %>


### PR DESCRIPTION
Make it possible to add an absence on the employees view by adding a link which redirects to the the personal calendar and opens up the add absence dialogue on the selected date.
